### PR TITLE
Fix duplicate license expiry handling

### DIFF
--- a/src/redfetch/sync_discovery.py
+++ b/src/redfetch/sync_discovery.py
@@ -159,6 +159,8 @@ def _root_sources_for_full_sync(
         spec.sources.add("watching")
         spec.payload = payload
 
+    license_validity: dict[str, bool] = {}
+
     for license_info in licenses:
         if not license_info.get("active", False):
             continue
@@ -171,9 +173,18 @@ def _root_sources_for_full_sync(
         resource_id = str(payload["resource_id"])
         spec = specs.setdefault(resource_id, _RootSpec())
         spec.sources.add("licensed")
-        if is_expired:
+        had_valid_license = license_validity.get(resource_id, False)
+        has_valid_license = not is_expired
+        license_validity[resource_id] = had_valid_license or has_valid_license
+
+        # Prefer payload from a valid license when duplicate license rows exist.
+        if spec.payload is None or (has_valid_license and not had_valid_license):
+            spec.payload = payload
+
+        if license_validity[resource_id]:
+            spec.discovery_block = None
+        else:
             spec.discovery_block = "license_expired"
-        spec.payload = payload
 
     settings_for_env = config.settings.from_env(settings_env)
     for resource_id, resource_info in settings_for_env.SPECIAL_RESOURCES.items():

--- a/tests/test_licensed_resources_filtering.py
+++ b/tests/test_licensed_resources_filtering.py
@@ -155,6 +155,22 @@ def test_unlimited_license_has_no_discovery_block():
     assert target.discovery_block is None
 
 
+def test_current_license_overrides_expired_duplicate_for_same_resource():
+    desired_set = asyncio.run(
+        _discover_from_licenses(
+            [
+                make_license(9998, 8, title="Expired Copy", end_date=PAST),
+                make_license(9998, 8, title="Current Copy", end_date=FAR_FUTURE),
+            ],
+            "LIVE",
+        )
+    )
+    target = desired_set.install_targets["/9998/"]
+    assert target.sources == {"licensed"}
+    assert target.discovery_block is None
+    assert target.title == "Current Copy"
+
+
 # --- expired license planner tests ---
 
 


### PR DESCRIPTION
## Summary
Fixes a Live sync bug where a resource could be blocked as `license_expired` if the user had duplicate license rows for the same plugin and one of those rows was expired.

## What changed
- treat a resource as licensed if any active license row for that resource is still valid or unlimited
- keep `license_expired` only when all active license rows for that resource are expired
- prefer payload data from a valid license row when duplicate rows exist
- add a regression test for the expired+current duplicate-license case reported in issue #21

## Testing
- Ran the Python 3.12 test suite locally
- Result: `58 passed`

Closes #21
