### PR TITLE
Group duplicate licenses by resource

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "redfetch"
 description = "Download and publish EverQuest scripts and software using the RedGuides API"
 readme = "README.md"
 license = "GPL-3.0-or-later"
+requires-python = ">=3.12"
 dynamic = ["version", "urls"]
 authors = [
     { name = "Redbot", email = "ask@redguides.com" }

--- a/src/redfetch/sync_discovery.py
+++ b/src/redfetch/sync_discovery.py
@@ -159,6 +159,8 @@ def _root_sources_for_full_sync(
         spec.sources.add("watching")
         spec.payload = payload
 
+    license_validity: dict[str, bool] = {}
+
     for license_info in licenses:
         if not license_info.get("active", False):
             continue
@@ -171,9 +173,18 @@ def _root_sources_for_full_sync(
         resource_id = str(payload["resource_id"])
         spec = specs.setdefault(resource_id, _RootSpec())
         spec.sources.add("licensed")
-        if is_expired:
+        had_valid_license = license_validity.get(resource_id, False)
+        has_valid_license = not is_expired
+        license_validity[resource_id] = had_valid_license or has_valid_license
+
+        # Prefer payload from a valid license when duplicate license rows exist.
+        if spec.payload is None or (has_valid_license and not had_valid_license):
+            spec.payload = payload
+
+        if license_validity[resource_id]:
+            spec.discovery_block = None
+        else:
             spec.discovery_block = "license_expired"
-        spec.payload = payload
 
     settings_for_env = config.settings.from_env(settings_env)
     for resource_id, resource_info in settings_for_env.SPECIAL_RESOURCES.items():

--- a/src/redfetch/sync_discovery.py
+++ b/src/redfetch/sync_discovery.py
@@ -159,6 +159,7 @@ def _root_sources_for_full_sync(
         spec.sources.add("watching")
         spec.payload = payload
 
+    licenses_by_resource: dict[str, list[tuple[dict, bool]]] = {}
     for license_info in licenses:
         if not license_info.get("active", False):
             continue
@@ -169,11 +170,21 @@ def _root_sources_for_full_sync(
         if not _category_allowed_in_env(category_id, settings_env):
             continue
         resource_id = str(payload["resource_id"])
+        licenses_by_resource.setdefault(resource_id, []).append((payload, is_expired))
+
+    for resource_id, resource_licenses in licenses_by_resource.items():
         spec = specs.setdefault(resource_id, _RootSpec())
         spec.sources.add("licensed")
-        if is_expired:
+        valid_license = next(
+            (lic_payload for lic_payload, is_expired in resource_licenses if not is_expired),
+            None,
+        )
+        if valid_license is None:
             spec.discovery_block = "license_expired"
-        spec.payload = payload
+            spec.payload = resource_licenses[0][0]
+        else:
+            spec.discovery_block = None
+            spec.payload = valid_license
 
     settings_for_env = config.settings.from_env(settings_env)
     for resource_id, resource_info in settings_for_env.SPECIAL_RESOURCES.items():

--- a/tests/test_licensed_resources_filtering.py
+++ b/tests/test_licensed_resources_filtering.py
@@ -155,6 +155,22 @@ def test_unlimited_license_has_no_discovery_block():
     assert target.discovery_block is None
 
 
+def test_current_license_overrides_expired_duplicate_for_same_resource():
+    desired_set = asyncio.run(
+        _discover_from_licenses(
+            [
+                make_license(9998, 8, title="Expired Copy", end_date=PAST),
+                make_license(9998, 8, title="Current Copy", end_date=FAR_FUTURE),
+            ],
+            "LIVE",
+        )
+    )
+    target = desired_set.install_targets["/9998/"]
+    assert target.sources == {"licensed"}
+    assert target.discovery_block is None
+    assert target.title == "Current Copy"
+
+
 # --- expired license planner tests ---
 
 

--- a/tests/test_licensed_resources_filtering.py
+++ b/tests/test_licensed_resources_filtering.py
@@ -54,7 +54,11 @@ def make_license(
     }
 
 
-async def _discover_from_licenses(licenses: list[dict], env: str):
+async def _discover_from_licenses(
+    licenses: list[dict],
+    env: str,
+    watched_resources: list[dict] | None = None,
+):
     mock_settings = MagicMock()
     mock_settings.ENV = env
     mock_settings.from_env.return_value = SimpleNamespace(
@@ -66,7 +70,7 @@ async def _discover_from_licenses(licenses: list[dict], env: str):
 
     with patch(
         "redfetch.sync_discovery.api.fetch_watched_resources",
-        new=AsyncMock(return_value=[]),
+        new=AsyncMock(return_value=watched_resources or []),
     ), patch(
         "redfetch.sync_discovery.api.fetch_licenses",
         new=AsyncMock(return_value=licenses),
@@ -153,6 +157,84 @@ def test_unlimited_license_has_no_discovery_block():
     target = desired_set.install_targets["/9998/"]
     assert target.sources == {"licensed"}
     assert target.discovery_block is None
+
+
+def test_current_license_overrides_expired_duplicate_for_same_resource():
+    desired_set = asyncio.run(
+        _discover_from_licenses(
+            [
+                make_license(9998, 8, title="Expired Copy", end_date=PAST),
+                make_license(9998, 8, title="Current Copy", end_date=FAR_FUTURE),
+            ],
+            "LIVE",
+        )
+    )
+    target = desired_set.install_targets["/9998/"]
+    assert target.sources == {"licensed"}
+    assert target.discovery_block is None
+    assert target.title == "Current Copy"
+
+
+def test_current_first_expired_second_no_block():
+    desired_set = asyncio.run(
+        _discover_from_licenses(
+            [
+                make_license(9998, 8, title="Current Copy", end_date=FAR_FUTURE),
+                make_license(9998, 8, title="Expired Copy", end_date=PAST),
+            ],
+            "LIVE",
+        )
+    )
+    target = desired_set.install_targets["/9998/"]
+    assert target.discovery_block is None
+    assert target.title == "Current Copy"
+
+
+def test_all_duplicate_licenses_expired_gets_block():
+    desired_set = asyncio.run(
+        _discover_from_licenses(
+            [
+                make_license(9998, 8, title="Expired A", end_date=PAST),
+                make_license(9998, 8, title="Expired B", end_date=PAST - 1),
+            ],
+            "LIVE",
+        )
+    )
+    target = desired_set.install_targets["/9998/"]
+    assert target.discovery_block == "license_expired"
+
+
+def test_unlimited_license_overrides_expired_duplicate():
+    desired_set = asyncio.run(
+        _discover_from_licenses(
+            [
+                make_license(9998, 8, title="Expired Copy", end_date=PAST),
+                make_license(9998, 8, title="Unlimited Copy", end_date=0),
+            ],
+            "LIVE",
+        )
+    )
+    target = desired_set.install_targets["/9998/"]
+    assert target.discovery_block is None
+    assert target.title == "Unlimited Copy"
+
+
+def test_watched_resource_with_valid_duplicate_license_is_not_blocked():
+    watched_resource = make_license(9998, 8, title="Watched Copy")["resource"]
+    desired_set = asyncio.run(
+        _discover_from_licenses(
+            [
+                make_license(9998, 8, title="Expired Copy", end_date=PAST),
+                make_license(9998, 8, title="Current Copy", end_date=FAR_FUTURE),
+            ],
+            "LIVE",
+            watched_resources=[watched_resource],
+        )
+    )
+    target = desired_set.install_targets["/9998/"]
+    assert target.sources == {"watching", "licensed"}
+    assert target.discovery_block is None
+    assert target.title == "Current Copy"
 
 
 # --- expired license planner tests ---


### PR DESCRIPTION
﻿## Summary

Refactors full-sync license discovery so duplicate license rows are grouped by `resource_id` before deciding whether a resource should be blocked as `license_expired`.

## What changed

- Collect active, environment-allowed license rows by resource.
- Treat a resource as licensed if any grouped row is current or unlimited.
- Keep `license_expired` only when all active allowed rows for that resource are expired.
- Prefer payload data from a valid license row when duplicate rows exist.
- Add regression coverage for duplicate license row order, all-expired duplicates, unlimited licenses, and watched resources with duplicate license rows.
- Declare the existing Python 3.12 requirement in package metadata.

## Validation

- Ran the full test suite locally: `uv run --with pytest --with pytest-mock pytest` - `81 passed`
- Ran the focused licensed-resource tests locally: `tests/test_licensed_resources_filtering.py` - `19 passed`
- Built a local wheel with `uv build`
- Ran on a local PC and completed a full update against an account with several expired licenses present, including MQ2Mage, MQ2Rogue, MQ2Bard, MQ2Wizard, and MQ2Zerker

Closes #21
