### PR TITLE
Add EQBCS post-update autorun option

### DIFF
--- a/src/redfetch/main.py
+++ b/src/redfetch/main.py
@@ -177,6 +177,22 @@ def prompt_auto_run_macroquest() -> None:
         console.print("MacroQuest path not found. Please check your configuration.")
 
 
+def auto_run_eqbcs_if_enabled() -> None:
+    """Start EQBCS after a successful update when configured to do so."""
+    if os.environ.get("CI") == "true" or sys.platform != "win32":
+        return
+
+    auto_run_eqbcs = config.settings.from_env(config.settings.ENV).get("AUTO_RUN_EQBCS", False)
+    if not auto_run_eqbcs:
+        return
+
+    mq_path = utils.get_vvmq_path()
+    if mq_path:
+        processes.run_executable(mq_path, "EQBCS.exe")
+    else:
+        console.print("MacroQuest path not found. Please check your configuration.")
+
+
 async def handle_download_watched_async(db_path: str, headers: dict) -> bool:
     """Run the main 'update watched' flow using async network calls."""
     if await net.is_mq_down():
@@ -201,6 +217,7 @@ async def handle_download_watched_async(db_path: str, headers: dict) -> bool:
         db_path, headers, navmesh_override=navmesh_override
     )
     if success:
+        auto_run_eqbcs_if_enabled()
         prompt_auto_run_macroquest()
         return True
     return False

--- a/src/redfetch/settings.toml
+++ b/src/redfetch/settings.toml
@@ -8,6 +8,7 @@
 [DEFAULT]
 DOWNLOAD_FOLDER = "@format {env[REDFETCH_DATA_DIR]}/Downloads"
 EQPATH = ""
+AUTO_RUN_EQBCS = false
 
 # ========================================
 # XenForo OAuth2

--- a/src/redfetch/terminal_ui.py
+++ b/src/redfetch/terminal_ui.py
@@ -501,6 +501,14 @@ class SettingsTab(ScrollableContainer):
                 ),
                 tooltip="Automatically run Very Vanilla MQ after successful updates.",
             )
+            yield Label("Start EQBCS post-update:", classes="left_middle")
+            yield Switch(
+                id="auto_run_eqbcs",
+                value=config.settings.from_env(current_env).get(
+                    "AUTO_RUN_EQBCS", False
+                ),
+                tooltip="Automatically run EQBCS.exe after successful updates.",
+            )
             if sys.platform == "win32":
                 yield Label("Desktop shortcut:", classes="left_middle")
                 yield Switch(
@@ -560,6 +568,9 @@ class SettingsTab(ScrollableContainer):
         # Update env-specific switches
         auto_run_vvmq_switch = self.query_one("#auto_run_vvmq", Switch)
         auto_run_vvmq_switch.value = settings_for_env.get("AUTO_RUN_VVMQ", None)
+
+        auto_run_eqbcs_switch = self.query_one("#auto_run_eqbcs", Switch)
+        auto_run_eqbcs_switch.value = settings_for_env.get("AUTO_RUN_EQBCS", False)
 
         auto_terminate_switch = self.query_one("#auto_terminate_processes", Switch)
         auto_terminate_switch.value = settings_for_env.get("AUTO_TERMINATE_PROCESSES", None)
@@ -674,6 +685,8 @@ class SettingsTab(ScrollableContainer):
             self.app.handle_toggle_navmesh(event.value)
         elif event.switch.id == "auto_run_vvmq":
             self.app.handle_toggle_auto_run_vvmq(event.value)
+        elif event.switch.id == "auto_run_eqbcs":
+            self.app.handle_toggle_auto_run_eqbcs(event.value)
         elif event.switch.id == "auto_terminate_processes":
             self.app.handle_toggle_auto_terminate_processes(event.value)
         elif event.switch.id == "desktop_shortcut":
@@ -1517,6 +1530,16 @@ class Redfetch(App):
         if main_screen:
             main_screen.query_one("#auto_run_vvmq", Switch).value = value
 
+    def handle_toggle_auto_run_eqbcs(self, value: bool) -> None:
+        main_screen = self._get_main_screen()
+        current_value = config.settings.from_env(self.current_env).get('AUTO_RUN_EQBCS', False)
+        if current_value != value:
+            config.update_setting(['AUTO_RUN_EQBCS'], value, env=self.current_env)
+            state = "enabled" if value else "disabled"
+            self.notify(f"Auto-run EQBCS is now {state}")
+        if main_screen:
+            main_screen.query_one("#auto_run_eqbcs", Switch).value = value
+
     #
     # Settings updaters
     #
@@ -1687,6 +1710,15 @@ class Redfetch(App):
             self.notify(f"{executable_name} started successfully.")
         else:
             self.notify(f"Failed to start {executable_name}", severity="error")
+
+    def auto_run_eqbcs_if_enabled(self) -> None:
+        """Start EQBCS after a successful update when configured to do so."""
+        if sys.platform != "win32":
+            return
+
+        auto_run_eqbcs = config.settings.from_env(self.current_env).get("AUTO_RUN_EQBCS", False)
+        if auto_run_eqbcs:
+            self.run_executable(utils.get_vvmq_path(), "EQBCS.exe")
 
     def run_myseq_executable(self) -> None:
         myseq_path = utils.get_myseq_path()
@@ -1929,6 +1961,7 @@ class Redfetch(App):
                 self.set_timer(6, lambda: main_screen.reset_button("update_resource_id", "default"))
             elif button.id == "update_watched":
                 if sys.platform == 'win32':
+                    self.auto_run_eqbcs_if_enabled()
                     auto_run = config.settings.from_env(self.current_env).get('AUTO_RUN_VVMQ', None)
                     if auto_run is True:
                         self.run_executable(utils.get_vvmq_path(), "MacroQuest.exe")

--- a/src/redfetch/terminal_ui.tcss
+++ b/src/redfetch/terminal_ui.tcss
@@ -237,7 +237,7 @@ Label {
 #dropdowns_grid {
     min-width: 30;
 }
-#dl_path_input, #eq_path_input, #vvmq_path_input, #auto_terminate_processes, #auto_run_vvmq, #desktop_shortcut {
+#dl_path_input, #eq_path_input, #vvmq_path_input, #auto_terminate_processes, #auto_run_vvmq, #auto_run_eqbcs, #desktop_shortcut {
     column-span: 3;
 }
 #myseq, #ionbc, #navmesh {

--- a/tests/test_auto_run_eqbcs.py
+++ b/tests/test_auto_run_eqbcs.py
@@ -1,0 +1,41 @@
+import importlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from redfetch import config
+
+
+class _SettingsStub:
+    ENV = "LIVE"
+
+    def __init__(self, values):
+        self._values = values
+
+    def from_env(self, env):
+        return self._values
+
+
+def test_main_auto_run_eqbcs_if_enabled(monkeypatch):
+    monkeypatch.setattr(config, "settings", _SettingsStub({"AUTO_RUN_EQBCS": True}), raising=False)
+    main = importlib.import_module("redfetch.main")
+
+    with patch("redfetch.main.utils.get_vvmq_path", return_value="C:/MQ"), \
+         patch("redfetch.main.processes.run_executable") as run_mock, \
+         patch("redfetch.main.sys.platform", "win32"), \
+         patch.dict("redfetch.main.os.environ", {}, clear=True):
+        main.auto_run_eqbcs_if_enabled()
+
+    run_mock.assert_called_once_with("C:/MQ", "EQBCS.exe")
+
+
+def test_terminal_ui_auto_run_eqbcs_if_enabled(monkeypatch):
+    monkeypatch.setattr(config, "settings", _SettingsStub({"AUTO_RUN_EQBCS": True}), raising=False)
+    Redfetch = importlib.import_module("redfetch.terminal_ui").Redfetch
+
+    app = SimpleNamespace(current_env="LIVE", run_executable=MagicMock())
+
+    with patch("redfetch.terminal_ui.utils.get_vvmq_path", return_value="C:/MQ"), \
+         patch("redfetch.terminal_ui.sys.platform", "win32"):
+        Redfetch.auto_run_eqbcs_if_enabled(app)
+
+    app.run_executable.assert_called_once_with("C:/MQ", "EQBCS.exe")


### PR DESCRIPTION
Adds a separate Settings toggle to automatically start `EQBCS.exe` after successful updates, restoring the older launcher behavior without tying it to the MacroQuest autorun setting.

## What changed
- add a new `AUTO_RUN_EQBCS` setting
- add a `Start EQBCS post-update` toggle directly under `Start MQ post-update` in Settings
- run `EQBCS.exe` after successful updates when enabled
- keep `AUTO_RUN_VVMQ` separate so users can control MQ and EQBCS independently
- add focused tests covering the CLI and TUI autorun helpers

## Testing
- Ran `tests/test_auto_run_eqbcs.py`
- Result: `2 passed`

Related to #18
