### PR TITLE
[codex] Keep easy update success state

### DIFF
--- a/src/redfetch/terminal_ui.py
+++ b/src/redfetch/terminal_ui.py
@@ -1932,11 +1932,8 @@ class Redfetch(App):
                     auto_run = config.settings.from_env(self.current_env).get('AUTO_RUN_VVMQ', None)
                     if auto_run is True:
                         self.run_executable(utils.get_vvmq_path(), "MacroQuest.exe")
-                        if main_screen:
-                            self.set_timer(6, lambda: main_screen.reset_button("update_watched", "primary"))
                     elif auto_run is False:
-                        if main_screen:
-                            self.set_timer(6, lambda: main_screen.reset_button("update_watched", "primary"))
+                        pass
                     else:
                         def handle_vvmq_response(response: str) -> None:
                             if response in [RunVVMQScreen.RESPONSE_RUN, RunVVMQScreen.RESPONSE_ALWAYS]:
@@ -1945,13 +1942,9 @@ class Redfetch(App):
                                 self.run_executable(utils.get_vvmq_path(), "MacroQuest.exe")
                             elif response == RunVVMQScreen.RESPONSE_NEVER:
                                 self.handle_toggle_auto_run_vvmq(False)
-                            if main_screen:
-                                main_screen.reset_button("update_watched", "primary")
-                                main_screen.update_widget_states()
                         self.push_screen(RunVVMQScreen(), handle_vvmq_response)
                 else:
-                    if main_screen:
-                        self.set_timer(6, lambda: main_screen.reset_button("update_watched", "primary"))
+                    pass
         else:
             button.variant = "error"
             print("Some resources failed to update.")


### PR DESCRIPTION
## Summary

Keeps the Easy Update button in its success state after a watched update completes successfully.

## Why

The button was being reset back to the primary/blue state by several watched-update completion paths, even though a successful update should remain visibly successful until another update is needed or the app restarts.

## Details

- Removed watched-update reset timers after successful updates.
- Removed the VVMQ modal callback reset for the watched-update button.
- Left the single-resource update button reset behavior unchanged.

## Validation

- `python -m py_compile src\redfetch\terminal_ui.py`
- `python -m pytest tests\test_first_run_setup.py tests\test_path_reset.py tests\test_licensed_resources_filtering.py`
