### PR TITLE
Keep easy update success state

### DIFF
--- a/src/redfetch/terminal_ui.py
+++ b/src/redfetch/terminal_ui.py
@@ -1932,11 +1932,8 @@ class Redfetch(App):
                     auto_run = config.settings.from_env(self.current_env).get('AUTO_RUN_VVMQ', None)
                     if auto_run is True:
                         self.run_executable(utils.get_vvmq_path(), "MacroQuest.exe")
-                        if main_screen:
-                            self.set_timer(6, lambda: main_screen.reset_button("update_watched", "primary"))
                     elif auto_run is False:
-                        if main_screen:
-                            self.set_timer(6, lambda: main_screen.reset_button("update_watched", "primary"))
+                        pass
                     else:
                         def handle_vvmq_response(response: str) -> None:
                             if response in [RunVVMQScreen.RESPONSE_RUN, RunVVMQScreen.RESPONSE_ALWAYS]:
@@ -1945,13 +1942,9 @@ class Redfetch(App):
                                 self.run_executable(utils.get_vvmq_path(), "MacroQuest.exe")
                             elif response == RunVVMQScreen.RESPONSE_NEVER:
                                 self.handle_toggle_auto_run_vvmq(False)
-                            if main_screen:
-                                main_screen.reset_button("update_watched", "primary")
-                                main_screen.update_widget_states()
                         self.push_screen(RunVVMQScreen(), handle_vvmq_response)
                 else:
-                    if main_screen:
-                        self.set_timer(6, lambda: main_screen.reset_button("update_watched", "primary"))
+                    pass
         else:
             button.variant = "error"
             print("Some resources failed to update.")


### PR DESCRIPTION
## Summary

Keeps the Easy Update button in its success state after a watched update completes successfully.

## Why

The watched-update completion path was resetting the button back to the primary/blue state after a successful update, which made a completed update look less clearly successful.

## Details

- Leaves the watched Easy Update button in the success state after successful watched updates.
- Keeps single-resource update reset behavior unchanged.
- Keeps failure behavior unchanged.

## Validation

- `python -m compileall -q src tests`
- `uv run --with pytest --with pytest-mock pytest`
- `git diff --check origin/main...HEAD`
