### PR TITLE
hook up redfetch to call luarocks.exe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "platformdirs~=4.5",
     "psutil~=7.2",
     "pyperclip~=1.11",
+    "pyyaml~=6.0",
     "rich~=14.3",
     "tenacity~=9.1",
     "textual~=8.1",

--- a/src/redfetch/luarocks.py
+++ b/src/redfetch/luarocks.py
@@ -1,0 +1,368 @@
+"""Pre-install MacroQuest's curated LuaRocks modules """
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+
+import httpx
+import yaml
+
+from redfetch import config, net
+from redfetch.sync_types import SyncEventCallback
+from redfetch.utils import get_vvmq_path
+
+
+REPO_BASE_URL = "https://luarocks.macroquest.org"
+MANIFEST_URL = f"{REPO_BASE_URL}/mq_luarocks.yaml"
+
+LUA_VERSION = "5.1"
+
+# Per-package subprocess. luarocks.exe normally finishes in seconds.
+INSTALL_TIMEOUT_SECONDS = 180
+
+# Printed by luarocks when a requested install is already present in the tree.
+ALREADY_INSTALLED_MARKER = "already installed"
+
+THREAD_URL = "https://www.redguides.com/community/threads/luarocks-packman-lsqlite3-not-working-correctly.93938/"
+VC_REDIST_X86 = "https://aka.ms/vs/17/release/vc_redist.x86.exe"
+VC_REDIST_X64 = "https://aka.ms/vs/17/release/vc_redist.x64.exe"
+
+MQ2LUA_DLL = os.path.join("plugins", "MQ2Lua.dll")
+LUAJIT_VERSION_RE = re.compile(rb"LuaJIT\s+([0-9]+(?:\.[0-9A-Za-z-]+)+)")
+
+# detect the MQ build's architecture
+IMAGE_FILE_MACHINE_I386 = 0x014C
+IMAGE_FILE_MACHINE_AMD64 = 0x8664
+
+
+@dataclass(frozen=True)
+class Rock:
+    """One rock from the MQ manifest."""
+    name: str
+    files: list[str] = field(default_factory=list)  # e.g. ["lfs.dll", "socket\\core.dll"]
+
+
+def is_luarocks_enabled() -> bool:
+    """Default-on: enabled unless LUAROCKS_ENABLED is explicitly set to False."""
+    setting = config.settings.from_env(config.settings.ENV).get("LUAROCKS_ENABLED", None)
+    return setting is not False
+
+
+def _read_jit_version_from_mq2lua(vvmq_path: str) -> str | None:
+    """Read the LuaJIT version embedded in MQ2Lua.dll."""
+    dll_path = os.path.join(vvmq_path, MQ2LUA_DLL)
+    try:
+        with open(dll_path, "rb") as dll:
+            data = dll.read()
+    except OSError:
+        return None
+
+    match = LUAJIT_VERSION_RE.search(data)
+    if not match:
+        return None
+
+    return match.group(1).decode("ascii", errors="ignore")
+
+
+def _read_pe_machine(path: str) -> int | None:
+    """Read the PE COFF machine type from a Windows binary, or None if unreadable."""
+    try:
+        with open(path, "rb") as f:
+            if f.read(2) != b"MZ":
+                return None
+            f.seek(0x3C)
+            e_lfanew_bytes = f.read(4)
+            if len(e_lfanew_bytes) != 4:
+                return None
+            f.seek(int.from_bytes(e_lfanew_bytes, "little"))
+            if f.read(4) != b"PE\x00\x00":
+                return None
+            machine_bytes = f.read(2)
+            if len(machine_bytes) != 2:
+                return None
+            return int.from_bytes(machine_bytes, "little")
+    except OSError:
+        return None
+
+
+def _detect_mq_is_64bit(vvmq_path: str) -> bool | None:
+    """Whether the MQ build is 64-bit, read from MQ2Lua.dll. None if undetectable."""
+    machine = _read_pe_machine(os.path.join(vvmq_path, MQ2LUA_DLL))
+    if machine == IMAGE_FILE_MACHINE_AMD64:
+        return True
+    if machine == IMAGE_FILE_MACHINE_I386:
+        return False
+    return None
+
+
+def _vc_redist_url(vvmq_path: str) -> str:
+    """Pick the VC++ redistributable matching the MQ build; default to x64 if unsure."""
+    return VC_REDIST_X86 if _detect_mq_is_64bit(vvmq_path) is False else VC_REDIST_X64
+
+
+def _find_luarocks_tree(vvmq_path: str) -> tuple[str, str] | None:
+    """Resolve the active luarocks tree from the MQ2Lua.dll LuaJIT version."""
+    jit_version = _read_jit_version_from_mq2lua(vvmq_path)
+    if not jit_version:
+        return None
+
+    tree_path = os.path.join(vvmq_path, "modules", jit_version, "luarocks")
+    return jit_version, tree_path
+
+
+async def fetch_manifest() -> list[Rock] | None:
+    """Fetch and parse the MQ rock manifest."""
+    skip_msg = f"LuaRocks: skipping module bootstrap because {MANIFEST_URL} did not return a usable manifest."
+
+    try:
+        async with httpx.AsyncClient() as client:
+            text = await net.get_text(client, MANIFEST_URL)
+    except httpx.HTTPError as e:
+        print(f"LuaRocks: could not fetch the module manifest: {e}")
+        print(skip_msg)
+        return None
+
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as e:
+        print(f"LuaRocks: could not parse the module manifest: {e}")
+        print(skip_msg)
+        return None
+
+    return _parse_manifest(data)
+
+
+def _parse_manifest(data: object) -> list[Rock]:
+    """Turn the parsed YAML mapping into a list of Rock entries."""
+    if not isinstance(data, dict):
+        return []
+
+    rocks: list[Rock] = []
+    for name, info in data.items():
+        if not isinstance(info, dict):
+            info = {}
+        files = [str(f) for f in (info.get("files") or [])]
+        rocks.append(Rock(name=str(name), files=files))
+    return rocks
+
+
+def _file_in_tree(tree_path: str, rel: str) -> str:
+    """Resolve a manifest file path (which may use backslashes) inside the tree's lib dir."""
+    parts = rel.replace("\\", "/").split("/")
+    return os.path.join(tree_path, "lib", "lua", LUA_VERSION, *parts)
+
+
+def _rock_files_present(tree_path: str, rock: Rock) -> bool:
+    """True if every DLL the rock should provide exists on disk."""
+    if not rock.files:
+        return False
+    return all(os.path.isfile(_file_in_tree(tree_path, f)) for f in rock.files)
+
+
+def _is_rock_satisfied(tree_path: str, rock: Rock) -> bool:
+    """Whether a rock is already installed and can be skipped this run."""
+    if rock.files:
+        return _rock_files_present(tree_path, rock)
+    # Pure-Lua rocks have no DLL to verify, so trust luarocks' own record
+    recorded = os.path.join(tree_path, "lib", "luarocks", f"rocks-{LUA_VERSION}", rock.name)
+    return os.path.isdir(recorded)
+
+
+def _build_install_command(
+    luarocks_exe: str,
+    tree_path: str,
+    jit_version: str,
+    package: str,
+) -> list[str]:
+    """Mirror PackageMan.lua's install command line."""
+    cache_path = os.path.join(tree_path, "cache")
+    repo_url = f"{REPO_BASE_URL}/{jit_version}/"
+    return [
+        luarocks_exe,
+        "--cache",
+        cache_path,
+        "--lua-version",
+        LUA_VERSION,
+        "--skip-config-warning",
+        "--only-server",
+        repo_url,
+        "install",
+        "--deps-mode",
+        "none",
+        "--tree",
+        tree_path,
+        package,
+    ]
+
+
+def _run_install(cmd: list[str], cwd: str) -> tuple[str, str]:
+    """Run luarocks install and classify the result by its exit code."""
+    creationflags = 0
+    if sys.platform == "win32":
+        # CREATE_NO_WINDOW so users don't see a black cmd window flash.
+        creationflags = subprocess.CREATE_NO_WINDOW
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=INSTALL_TIMEOUT_SECONDS,
+            creationflags=creationflags,
+        )
+    except subprocess.TimeoutExpired as exc:
+        partial = (exc.stdout or "") + (exc.stderr or "")
+        return "error", f"luarocks.exe timed out after {INSTALL_TIMEOUT_SECONDS}s\n{partial}"
+    except OSError as exc:
+        return "error", f"Failed to launch luarocks.exe: {exc}"
+
+    output = (result.stdout or "") + (result.stderr or "")
+    if result.returncode == 0:
+        if ALREADY_INSTALLED_MARKER in output:
+            return "skipped", output
+        return "installed", output
+    return "error", output
+
+
+def _print_failure_hints(vvmq_path: str) -> None:
+    """Print the same forum-derived hints we already give users in support."""
+    print("  Hints:")
+    print("    - If this keeps failing, ensure luarocks.macroquest.org isn't blocked by your router/ISP.")
+    if _detect_mq_is_64bit(vvmq_path) is False:
+        print(f"    - This MQ build is 32-bit; install the x86 Visual C++ redistributable: {VC_REDIST_X86}")
+    else:
+        print(f"    - This MQ build is 64-bit; install the x64 Visual C++ redistributable: {VC_REDIST_X64}")
+    print("    - Set PackageMan.debug = true in lua/mq/PackageMan.lua for more detail.")
+    print(f"    - Troubleshooting thread: {THREAD_URL}")
+
+
+async def _install_rock(
+    rock: Rock,
+    *,
+    luarocks_exe: str,
+    tree_path: str,
+    jit_version: str,
+    cwd: str,
+    on_event: SyncEventCallback | None,
+) -> str:
+    """Install one rock and verify it landed on disk."""
+    if on_event:
+        on_event(("start", rock.name, None))
+
+    cmd = _build_install_command(luarocks_exe, tree_path, jit_version, rock.name)
+    status, output = await asyncio.to_thread(_run_install, cmd, cwd)
+
+    if status in {"installed", "skipped"} and rock.files and not _rock_files_present(tree_path, rock):
+        status = "error"
+        output = (
+            f"{output}\nluarocks reported success but expected file(s) are "
+            f"missing: {', '.join(rock.files)} (antivirus may have removed them)"
+        )
+
+    if status == "installed":
+        print(f"LuaRocks: {rock.name} installed.")
+        if on_event:
+            on_event(("done", rock.name, "downloaded"))
+        return "installed"
+
+    if status == "skipped":
+        if on_event:
+            on_event(("done", rock.name, "skipped"))
+        return "skipped"
+
+    print(f"LuaRocks: {rock.name} failed to install.")
+    print(f"  Command: {subprocess.list2cmdline(cmd)}")
+    stripped = output.strip()
+    if stripped:
+        print("  Output:")
+        for line in stripped.splitlines():
+            print(f"    {line}")
+    if on_event:
+        on_event(("done", rock.name, "error"))
+    return "error"
+
+
+async def bootstrap_modules(
+    on_event: SyncEventCallback | None = None,
+) -> bool:
+    """Pre-install the MQ-curated LuaRocks modules into the MQ modules tree."""
+    if sys.platform != "win32":
+        return True
+
+    if not is_luarocks_enabled():
+        return True
+
+    vvmq_path = get_vvmq_path()
+    if not vvmq_path:
+        return True
+
+    luarocks_exe = os.path.join(vvmq_path, "luarocks.exe")
+    if not os.path.isfile(luarocks_exe):
+        return True
+
+    tree_info = _find_luarocks_tree(vvmq_path)
+    if tree_info is None:
+        return True
+
+    jit_version, tree_path = tree_info
+    try:
+        os.makedirs(os.path.join(tree_path, "cache"), exist_ok=True)
+    except OSError as exc:
+        print(f"LuaRocks: could not prepare module tree: {exc}")
+        return True
+
+    rocks = await fetch_manifest()
+    if not rocks:
+        # Could not learn what to install; don't fail the sync over it.
+        return True
+
+    to_install = [rock for rock in rocks if not _is_rock_satisfied(tree_path, rock)]
+
+    if not to_install:
+        print("LuaRocks modules up-to-date.")
+        return True
+
+    if on_event:
+        on_event(("add_total", len(to_install), None))
+
+    print(f"LuaRocks: installing {len(to_install)} module(s); this can take several minutes...")
+
+    installed = 0
+    failed: list[str] = []
+
+    # Serial on purpose: all rocks share one cache/tree, so parallel installs could race.
+    for rock in to_install:
+        status = await _install_rock(
+            rock,
+            luarocks_exe=luarocks_exe,
+            tree_path=tree_path,
+            jit_version=jit_version,
+            cwd=vvmq_path,
+            on_event=on_event,
+        )
+        if status == "installed":
+            installed += 1
+        elif status == "error":
+            failed.append(rock.name)
+
+    if failed:
+        print(f"LuaRocks: {len(failed)} package(s) failed: {', '.join(failed)}")
+        _print_failure_hints(vvmq_path)
+        if on_event:
+            on_event(("luarocks_failed", _vc_redist_url(vvmq_path), None))
+        return False
+
+    if installed:
+        print(f"LuaRocks: installed {installed} module(s).")
+    else:
+        print("LuaRocks modules up-to-date.")
+
+    return True

--- a/src/redfetch/net.py
+++ b/src/redfetch/net.py
@@ -63,6 +63,19 @@ async def get_json(client: httpx.AsyncClient, url: str, params: Optional[Dict[st
     return response.json()
 
 
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=0.5, min=0.5, max=4),
+    retry=retry_if_exception_type(httpx.RequestError),
+    reraise=True,
+)
+async def get_text(client: httpx.AsyncClient, url: str) -> str:
+    """GET raw text with retry on transient network errors."""
+    response = await client.get(url, timeout=30.0)
+    response.raise_for_status()
+    return response.text
+
+
 async def fetch_manifest_cached(client: httpx.AsyncClient) -> dict:
     """Fetch manifest with a 60-second cache."""
     manifest = _manifest_cache.get("manifest")

--- a/src/redfetch/settings.toml
+++ b/src/redfetch/settings.toml
@@ -27,6 +27,7 @@ opt_in = false
 # ========================================
 [LIVE]
 THEME = "textual-dark"
+LUAROCKS_ENABLED = true
 
 [LIVE.PROTECTED_FILES_BY_RESOURCE]
 1974 = ["CharSelect.cfg", "Zoned.cfg", "MQ2Map.ini", "MQ2MoveUtils.ini"]
@@ -127,6 +128,7 @@ staff_pick = true
 # ========================================
 [TEST]
 THEME = "gruvbox"
+LUAROCKS_ENABLED = true
 
 [TEST.PROTECTED_FILES_BY_RESOURCE]
 2218 = ["CharSelect.cfg", "Zoned.cfg", "MQ2Map.ini", "MQ2MoveUtils.ini"]
@@ -227,6 +229,7 @@ staff_pick = true
 # ========================================
 [EMU]
 THEME = "dracula"
+LUAROCKS_ENABLED = true
 
 [EMU.PROTECTED_FILES_BY_RESOURCE]
 60 = ["CharSelect.cfg", "Zoned.cfg", "MQ2Map.ini", "MQ2MoveUtils.ini"]

--- a/src/redfetch/sync.py
+++ b/src/redfetch/sync.py
@@ -255,6 +255,14 @@ async def run_sync(
                 if not navmesh_ok:
                     print("navmesh sync encountered errors")
 
+                from redfetch import luarocks
+
+                luarocks_ok = await luarocks.bootstrap_modules(
+                    on_event=on_event,
+                )
+                if not luarocks_ok:
+                    print("luarocks bootstrap encountered errors")
+
             return result
     except (KeyboardInterrupt, asyncio.CancelledError):
         print("Download cancelled by user.")

--- a/src/redfetch/sync_types.py
+++ b/src/redfetch/sync_types.py
@@ -78,6 +78,8 @@ SyncEvent = (
     | tuple[Literal["add_total"], int, None]
     | tuple[Literal["start"], str, str | None]
     | tuple[Literal["done"], str, ResultOutcome]
+    # VC++ redistributable URL if needed
+    | tuple[Literal["luarocks_failed"], str, None]
 )
 SyncEventCallback = Callable[[SyncEvent], None]
 

--- a/src/redfetch/terminal_ui.py
+++ b/src/redfetch/terminal_ui.py
@@ -450,6 +450,15 @@ class SettingsTab(ScrollableContainer):
                     "Download pre-made navigation meshes for the Nav plugin (via mqmesh.com). "
                 ),
             )
+            yield Label("LuaRocks:", classes="left_middle")
+            yield Switch(
+                id="luarocks",
+                value=config.settings.from_env(current_env).get("LUAROCKS_ENABLED", True),
+                tooltip=(
+                    "Pre-install common Lua modules (lfs, lsqlite3) into MacroQuest's "
+                    "modules folder. Windows only."
+                ),
+            )
             yield Label("Maps:", classes="left_middle")
             yield Select(
                 [("Brewall's Maps", "brewall"), ("Good's Maps", "good"), ("All", "all")],
@@ -462,7 +471,6 @@ class SettingsTab(ScrollableContainer):
                     "normal EverQuest map, using Brewall and Good's folders."
                 ),
             )
-            yield Static(classes="spacer_for_special_resources")
             yield Label("IonBC:", classes="left_middle")
             yield Switch(
                 id="ionbc",
@@ -554,6 +562,11 @@ class SettingsTab(ScrollableContainer):
         # NavMesh switch - requires VVMQ path to be configured
         self.query_one("#navmesh", Switch).disabled = not bool(utils.get_vvmq_path())
 
+        # LuaRocks switch - Windows only and requires VVMQ path
+        self.query_one("#luarocks", Switch).disabled = (
+            sys.platform != "win32" or not bool(utils.get_vvmq_path())
+        )
+
         # Environment-specific settings for the current env
         settings_for_env = config.settings.from_env(app.current_env)
 
@@ -566,6 +579,16 @@ class SettingsTab(ScrollableContainer):
 
         navmesh_switch = self.query_one("#navmesh", Switch)
         navmesh_switch.value = settings_for_env.get("NAVMESH_OPT_IN", False)
+
+        ionbc_switch = self.query_one("#ionbc", Switch)
+        ionbc_switch.value = (
+            config.settings.from_env("DEFAULT")
+            .SPECIAL_RESOURCES.get("2463", {})
+            .get("opt_in", False)
+        )
+
+        luarocks_switch = self.query_one("#luarocks", Switch)
+        luarocks_switch.value = settings_for_env.get("LUAROCKS_ENABLED", True)
 
         # Staff picks switch - per-environment setting
         staff_switch = self.query_one("#staff_picks", Switch)
@@ -672,6 +695,8 @@ class SettingsTab(ScrollableContainer):
             self.app.handle_toggle_staff_picks(event.value)
         elif event.switch.id == "navmesh":
             self.app.handle_toggle_navmesh(event.value)
+        elif event.switch.id == "luarocks":
+            self.app.handle_toggle_luarocks(event.value)
         elif event.switch.id == "auto_run_vvmq":
             self.app.handle_toggle_auto_run_vvmq(event.value)
         elif event.switch.id == "auto_terminate_processes":
@@ -1185,7 +1210,7 @@ class Redfetch(App):
         yield SystemCommand(
             "Upgrade to Level 2",
             "Upgrade your RedGuides account to level 2",
-            lambda: self.action_link("https://www.redguides.com/community/amember-sso/?to=member"),
+            lambda: self.action_link("https://www.redguides.com/community/amember-sso/?to=signup"),
             discover=False,
         )
 
@@ -1496,6 +1521,13 @@ class Redfetch(App):
             config.update_setting(['NAVMESH_OPT_IN'], value, env=self.current_env)
             state = "enabled" if value else "disabled"
             self.notify(f"navmesh downloads for {self.current_env} are now {state}")
+
+    def handle_toggle_luarocks(self, value: bool) -> None:
+        current_setting = config.settings.from_env(self.current_env).get('LUAROCKS_ENABLED', None)
+        if current_setting is None or current_setting != value:
+            config.update_setting(['LUAROCKS_ENABLED'], value, env=self.current_env)
+            state = "enabled" if value else "disabled"
+            self.notify(f"LuaRocks bootstrap for {self.current_env} is now {state}")
 
     def handle_toggle_auto_terminate_processes(self, value: bool) -> None:
         main_screen = self._get_main_screen()
@@ -1853,6 +1885,11 @@ class Redfetch(App):
 
     def on_sync_event(self, event: SyncEvent) -> None:
         """Handle events from the sync process to update the UI."""
+        if event[0] == "luarocks_failed":
+            _, redist_url, _ = event
+            self._show_luarocks_failure(redist_url)
+            return
+
         event_type, resource_id, details = event
         self._process_sync_event(event_type, resource_id, details)
 
@@ -1883,6 +1920,17 @@ class Redfetch(App):
                 progress_bar.advance(1)
         except Exception:
             pass
+
+    def _show_luarocks_failure(self, redist_url: str) -> None:
+        """Surface a LuaRocks install failure with a toast and a download modal."""
+        self.notify(
+            "Some MacroQuest Lua modules failed to install. You may be missing "
+            "the Microsoft Visual C++ runtime.",
+            title="LuaRocks",
+            severity="error",
+            timeout=10,
+        )
+        self.push_screen(LuaRocksFailedScreen(redist_url))
 
     async def run_synchronization(self, resource_ids=None, navmesh_override=None):
         try:
@@ -2103,9 +2151,9 @@ class Redfetch(App):
                 main_screen.update_account_label(greetingacct)
             self.notify("🎉 DING! Welcome to level 2!", severity="information")
         else:
-            # Still level 1, send them to the upgrade page
+            # Still level 1, send them to the signup page
             self.notify("You're still level 1. Opening upgrade page...", severity="warning")
-            self.action_link("https://www.redguides.com/community/amember-sso/?to=member")
+            self.action_link("https://www.redguides.com/community/amember-sso/?to=signup")
 
 
 # display print statements in the log widget
@@ -2173,6 +2221,37 @@ class NavMeshPromptScreen(ModalScreen):
             self.dismiss(self.RESPONSE_NEVER)
         else:
             self.dismiss(self.RESPONSE_NO)
+
+
+class LuaRocksFailedScreen(ModalScreen):
+    """Shown when the LuaRocks bootstrap fails; offers the VC++ redist download."""
+
+    RESPONSE_DOWNLOAD = "download"
+    RESPONSE_CLOSE = "close"
+
+    def __init__(self, redist_url: str):
+        super().__init__()
+        self.redist_url = redist_url
+
+    def compose(self) -> ComposeResult:
+        yield Grid(
+            Label("Some MacroQuest Lua modules failed to install.", id="luarocks_message"),
+            Label(
+                "This is usually a missing Microsoft Visual C++ runtime. Install it, "
+                "then run an update again. See the log for more details.",
+                id="luarocks_hint",
+            ),
+            Button("Download from Microsoft", variant="primary", id="download_redist"),
+            Button("Close", variant="default", id="close_luarocks"),
+            id="luarocks_dialog",
+        )
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "download_redist":
+            webbrowser.open(self.redist_url)
+            self.dismiss(self.RESPONSE_DOWNLOAD)
+        else:
+            self.dismiss(self.RESPONSE_CLOSE)
 
 
 class ProcessTerminationScreen(ModalScreen):

--- a/src/redfetch/terminal_ui.tcss
+++ b/src/redfetch/terminal_ui.tcss
@@ -223,9 +223,10 @@ Label {
 }
 #special_resources_grid {
     layout: grid;
-    grid-size: 4;  
-    grid-rows: auto;   
-    border: round $secondary-background;  
+    grid-size: 2;
+    grid-rows: auto;
+    grid-gutter: 1 0;
+    border: round $secondary-background;
     margin-bottom: 1;
     min-width: 50;
 }
@@ -239,15 +240,6 @@ Label {
 }
 #dl_path_input, #eq_path_input, #vvmq_path_input, #auto_terminate_processes, #auto_run_vvmq, #desktop_shortcut {
     column-span: 3;
-}
-#myseq, #ionbc, #navmesh {
-    column-span: 3;
-}
-#eq_maps {
-    column-span: 2;
-}
-.spacer_for_special_resources {
-    column-span: 1;
 }
 .bordertitles {
     border: round $secondary-background;
@@ -451,6 +443,41 @@ NavMeshPromptScreen Button {
 #nevermq:hover {
     background: $error-darken-1 15%;
     border-top: tall $error 15%;
+}
+
+LuaRocksFailedScreen {
+    align: center top;
+    background: $background-darken-2 70%;
+}
+
+LuaRocksFailedScreen Button {
+    width: 100%;
+}
+
+#luarocks_dialog {
+    grid-size: 2;
+    grid-gutter: 0 1;
+    margin: 4 1;
+    padding: 0 1;
+    width: 50;
+    height: 15;
+    border: thick $primary-background-darken-3;
+    background: $surface;
+}
+
+#luarocks_message {
+    color: $text-primary;
+    column-span: 2;
+    width: 100%;
+    content-align: center middle;
+    text-style: bold;
+}
+
+#luarocks_hint {
+    column-span: 2;
+    height: 1fr;
+    width: 100%;
+    content-align: center middle;
 }
 
 ProcessTerminationScreen {

--- a/tests/test_luarocks.py
+++ b/tests/test_luarocks.py
@@ -1,0 +1,551 @@
+"""Tests for the manifest-driven LuaRocks bootstrap module."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from redfetch import luarocks
+from redfetch.luarocks import Rock
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------- _parse_manifest ----------
+
+
+def test_parse_manifest_reads_files():
+    data = {
+        "luafilesystem": {"files": ["lfs.dll"]},
+        "luasocket": {"files": ["mime\\core.dll", "socket\\core.dll"]},
+        "fun": {},
+        "lsqlite3": {"files": ["lsqlite3.dll"], "external_deps": ["sqlite3"]},
+    }
+    rocks = {r.name: r for r in luarocks._parse_manifest(data)}
+
+    assert rocks["luafilesystem"].files == ["lfs.dll"]
+    assert rocks["luasocket"].files == ["mime\\core.dll", "socket\\core.dll"]
+    assert rocks["fun"].files == []
+    assert rocks["lsqlite3"].files == ["lsqlite3.dll"]
+
+
+def test_parse_manifest_handles_null_entry():
+    # A bare "argparse:" with no mapping parses to None in YAML.
+    rocks = {r.name: r for r in luarocks._parse_manifest({"argparse": None})}
+    assert rocks["argparse"].files == []
+
+
+def test_parse_manifest_non_dict_returns_empty():
+    assert luarocks._parse_manifest(None) == []
+    assert luarocks._parse_manifest("nonsense") == []
+
+
+def test_fetch_manifest_failure_warns_and_returns_none(monkeypatch, capsys):
+    class _FailingClient:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return None
+
+        async def get(self, _url, **_kw):
+            raise luarocks.httpx.ConnectError("down")
+
+    monkeypatch.setattr(luarocks.httpx, "AsyncClient", _FailingClient)
+
+    assert _run(luarocks.fetch_manifest()) is None
+    out = capsys.readouterr().out
+    assert "could not fetch" in out
+    assert "skipping module bootstrap" in out
+
+
+# ---------- _find_luarocks_tree ----------
+
+
+TEST_JIT_VERSION = "2.1.1734626439"
+
+
+def _mq2lua_bytes(version: str, machine: int) -> bytes:
+    """Build a minimal valid PE that also contains the LuaJIT version string."""
+    pe_offset = 0x80
+    buf = bytearray(pe_offset + 8)
+    buf[0:2] = b"MZ"
+    buf[0x3C:0x40] = pe_offset.to_bytes(4, "little")
+    buf[pe_offset:pe_offset + 4] = b"PE\x00\x00"
+    buf[pe_offset + 4:pe_offset + 6] = machine.to_bytes(2, "little")
+    buf += b"\x00LuaJIT " + version.encode("ascii") + b"\x00more noise"
+    return bytes(buf)
+
+
+def _write_mq2lua(
+    root: str,
+    version: str = TEST_JIT_VERSION,
+    machine: int = luarocks.IMAGE_FILE_MACHINE_AMD64,
+) -> str:
+    path = os.path.join(root, "plugins", "MQ2Lua.dll")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(_mq2lua_bytes(version, machine))
+    return path
+
+
+def _make_tree(root: str, version: str) -> str:
+    tree = os.path.join(root, "modules", version, "luarocks")
+    os.makedirs(tree)
+    return tree
+
+
+def test_read_jit_version_from_mq2lua(tmp_path):
+    _write_mq2lua(str(tmp_path), "2.1.1800000000")
+
+    assert luarocks._read_jit_version_from_mq2lua(str(tmp_path)) == "2.1.1800000000"
+
+
+def test_detect_mq_is_64bit_reads_pe_machine(tmp_path):
+    root64 = tmp_path / "x64"
+    root32 = tmp_path / "x86"
+    _write_mq2lua(str(root64), machine=luarocks.IMAGE_FILE_MACHINE_AMD64)
+    _write_mq2lua(str(root32), machine=luarocks.IMAGE_FILE_MACHINE_I386)
+
+    assert luarocks._detect_mq_is_64bit(str(root64)) is True
+    assert luarocks._detect_mq_is_64bit(str(root32)) is False
+
+
+def test_detect_mq_is_64bit_unknown_returns_none(tmp_path):
+    # Missing DLL, and a non-PE file, both yield None (undetectable).
+    assert luarocks._detect_mq_is_64bit(str(tmp_path)) is None
+    _write(os.path.join(str(tmp_path), "plugins", "MQ2Lua.dll"))
+    assert luarocks._detect_mq_is_64bit(str(tmp_path)) is None
+
+
+def test_vc_redist_url_matches_arch_and_defaults_to_x64(tmp_path):
+    root64 = tmp_path / "x64"
+    root32 = tmp_path / "x86"
+    _write_mq2lua(str(root64), machine=luarocks.IMAGE_FILE_MACHINE_AMD64)
+    _write_mq2lua(str(root32), machine=luarocks.IMAGE_FILE_MACHINE_I386)
+
+    assert luarocks._vc_redist_url(str(root64)) == luarocks.VC_REDIST_X64
+    assert luarocks._vc_redist_url(str(root32)) == luarocks.VC_REDIST_X86
+    # Undetectable -> safe default of x64.
+    assert luarocks._vc_redist_url(str(tmp_path / "missing")) == luarocks.VC_REDIST_X64
+
+
+def test_find_luarocks_tree_uses_mq2lua_version_without_existing_tree(tmp_path):
+    _write_mq2lua(str(tmp_path), TEST_JIT_VERSION)
+    expected = os.path.join(str(tmp_path), "modules", TEST_JIT_VERSION, "luarocks")
+
+    result = luarocks._find_luarocks_tree(str(tmp_path))
+    assert result is not None
+    version, tree = result
+    assert version == TEST_JIT_VERSION
+    assert os.path.normpath(tree) == os.path.normpath(expected)
+
+
+def test_find_luarocks_tree_ignores_existing_trees_without_mq2lua(tmp_path):
+    _make_tree(str(tmp_path), TEST_JIT_VERSION)
+
+    assert luarocks._find_luarocks_tree(str(tmp_path)) is None
+
+
+def test_find_luarocks_tree_none_returns_none(tmp_path):
+    assert luarocks._find_luarocks_tree(str(tmp_path)) is None
+    os.makedirs(os.path.join(str(tmp_path), "plugins"))
+    open(os.path.join(str(tmp_path), "plugins", "MQ2Lua.dll"), "wb").close()
+    assert luarocks._find_luarocks_tree(str(tmp_path)) is None
+
+
+# ---------- file / satisfied checks ----------
+
+
+def _write(path: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    open(path, "wb").close()
+
+
+def test_file_in_tree_normalizes_backslashes(tmp_path):
+    resolved = luarocks._file_in_tree(str(tmp_path), "socket\\core.dll")
+    assert os.path.normpath(resolved) == os.path.normpath(
+        os.path.join(str(tmp_path), "lib", "lua", "5.1", "socket", "core.dll")
+    )
+
+
+def test_rock_files_present_requires_all_files(tmp_path):
+    tree = str(tmp_path)
+    rock = Rock(name="luasocket", files=["mime\\core.dll", "socket\\core.dll"])
+    assert luarocks._rock_files_present(tree, rock) is False
+
+    _write(luarocks._file_in_tree(tree, "mime\\core.dll"))
+    assert luarocks._rock_files_present(tree, rock) is False  # still missing one
+
+    _write(luarocks._file_in_tree(tree, "socket\\core.dll"))
+    assert luarocks._rock_files_present(tree, rock) is True
+
+
+def test_is_rock_satisfied_binary_present(tmp_path):
+    tree = str(tmp_path)
+    binary = Rock(name="luafilesystem", files=["lfs.dll"])
+
+    assert luarocks._is_rock_satisfied(tree, binary) is False
+    _write(luarocks._file_in_tree(tree, "lfs.dll"))
+    assert luarocks._is_rock_satisfied(tree, binary) is True
+
+
+def test_is_rock_satisfied_pure_lua_uses_rocks_db(tmp_path):
+    # Pure-Lua rocks have no DLL to verify, so we trust luarocks' own record in
+    # the tree (lib/luarocks/rocks-5.1/{name}) to avoid a slow reinstall each run.
+    tree = str(tmp_path)
+    pure = Rock(name="fun")
+
+    assert luarocks._is_rock_satisfied(tree, pure) is False  # not recorded yet
+    os.makedirs(os.path.join(tree, "lib", "luarocks", "rocks-5.1", "fun"))
+    assert luarocks._is_rock_satisfied(tree, pure) is True
+
+
+# ---------- _build_install_command ----------
+
+
+def test_install_command_matches_packageman_shape():
+    cmd = luarocks._build_install_command(
+        luarocks_exe=r"C:\MQ\luarocks.exe",
+        tree_path=r"C:\MQ\modules\2.1.x\luarocks",
+        jit_version="2.1.x",
+        package="luafilesystem",
+    )
+    assert cmd[0] == r"C:\MQ\luarocks.exe"
+    assert cmd[cmd.index("--lua-version") + 1] == "5.1"
+    assert "--skip-config-warning" in cmd
+    assert cmd[cmd.index("--only-server") + 1] == "https://luarocks.macroquest.org/2.1.x/"
+    assert "install" in cmd
+    assert cmd[cmd.index("--deps-mode") + 1] == "none"
+    assert cmd[cmd.index("--tree") + 1] == r"C:\MQ\modules\2.1.x\luarocks"
+    assert cmd[-1] == "luafilesystem"
+
+
+# ---------- _run_install ----------
+
+
+class _FakeCompleted:
+    def __init__(self, stdout="", stderr="", returncode=0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def test_run_install_success_keyed_on_exit_code():
+    out = "luafilesystem 1.8.0-1 is now installed in C:\\MQ\\modules\\..."
+    with patch.object(luarocks.subprocess, "run", return_value=_FakeCompleted(stdout=out, returncode=0)):
+        status, _ = luarocks._run_install(["luarocks.exe"], cwd=".")
+    assert status == "installed"
+
+
+def test_run_install_already_installed_is_skipped():
+    out = "luafilesystem 1.8.0-1 is already installed in tree."
+    with patch.object(luarocks.subprocess, "run", return_value=_FakeCompleted(stdout=out, returncode=0)):
+        status, _ = luarocks._run_install(["luarocks.exe"], cwd=".")
+    assert status == "skipped"
+
+
+def test_run_install_dash_e_noise_does_not_fail():
+    # The cosmetic "-e flag" warning doesn't change luarocks' exit code.
+    out = "-e flag does not exist.\nluafilesystem 1.8.0-1 is now installed in tree.\n"
+    with patch.object(luarocks.subprocess, "run", return_value=_FakeCompleted(stdout=out, returncode=0)):
+        status, _ = luarocks._run_install(["luarocks.exe"], cwd=".")
+    assert status == "installed"
+
+
+def test_run_install_failure():
+    out = "Error: something else went wrong"
+    with patch.object(luarocks.subprocess, "run", return_value=_FakeCompleted(stderr=out, returncode=1)):
+        status, _ = luarocks._run_install(["luarocks.exe"], cwd=".")
+    assert status == "error"
+
+
+def test_run_install_handles_timeout():
+    exc = subprocess.TimeoutExpired(cmd=["luarocks.exe"], timeout=1, output="", stderr="")
+    with patch.object(luarocks.subprocess, "run", side_effect=exc):
+        status, out = luarocks._run_install(["luarocks.exe"], cwd=".")
+    assert status == "error"
+    assert "timed out" in out
+
+
+def test_run_install_handles_oserror():
+    with patch.object(luarocks.subprocess, "run", side_effect=OSError("not found")):
+        status, out = luarocks._run_install(["luarocks.exe"], cwd=".")
+    assert status == "error"
+    assert "Failed to launch" in out
+
+
+# ---------- bootstrap_modules: skip conditions ----------
+
+
+def _no_call(*_a, **_kw):
+    raise AssertionError("should not be called")
+
+
+def _enable_win(monkeypatch, vvmq):
+    monkeypatch.setattr(luarocks.sys, "platform", "win32")
+    monkeypatch.setattr(luarocks, "is_luarocks_enabled", lambda: True)
+    monkeypatch.setattr(luarocks, "get_vvmq_path", lambda: vvmq)
+    # In production config is initialized before the sync reaches bootstrap; the
+    # bootstrap path reads config.settings.ENV for the failure hints.
+    monkeypatch.setattr(luarocks.config, "settings", SimpleNamespace(ENV="LIVE"))
+
+
+def _patch_manifest(monkeypatch, rocks):
+    async def _fake():
+        return rocks
+    monkeypatch.setattr(luarocks, "fetch_manifest", _fake)
+
+
+
+
+def test_bootstrap_skipped_on_non_windows(monkeypatch):
+    monkeypatch.setattr(luarocks.sys, "platform", "linux")
+    monkeypatch.setattr(luarocks, "get_vvmq_path", _no_call)
+    assert _run(luarocks.bootstrap_modules()) is True
+
+
+def test_bootstrap_skipped_when_disabled(monkeypatch):
+    monkeypatch.setattr(luarocks.sys, "platform", "win32")
+    monkeypatch.setattr(luarocks, "is_luarocks_enabled", lambda: False)
+    monkeypatch.setattr(luarocks, "get_vvmq_path", _no_call)
+    assert _run(luarocks.bootstrap_modules()) is True
+
+
+def test_bootstrap_skipped_when_no_vvmq_path(monkeypatch):
+    monkeypatch.setattr(luarocks.sys, "platform", "win32")
+    monkeypatch.setattr(luarocks, "is_luarocks_enabled", lambda: True)
+    monkeypatch.setattr(luarocks, "get_vvmq_path", lambda: None)
+    assert _run(luarocks.bootstrap_modules()) is True
+
+
+def test_bootstrap_skipped_when_no_luarocks_exe(tmp_path, monkeypatch):
+    _enable_win(monkeypatch, str(tmp_path))
+    assert _run(luarocks.bootstrap_modules()) is True
+
+
+def test_bootstrap_skipped_when_no_mq2lua_dll(tmp_path, monkeypatch):
+    _enable_win(monkeypatch, str(tmp_path))
+    _write(os.path.join(str(tmp_path), "luarocks.exe"))
+    assert _run(luarocks.bootstrap_modules()) is True
+
+
+def test_bootstrap_skipped_when_manifest_unavailable(tmp_path, monkeypatch):
+    vvmq = str(tmp_path)
+    _enable_win(monkeypatch, vvmq)
+    _write(os.path.join(vvmq, "luarocks.exe"))
+    _write_mq2lua(vvmq)
+    _patch_manifest(monkeypatch, None)
+    monkeypatch.setattr(luarocks.subprocess, "run", _no_call)
+    assert _run(luarocks.bootstrap_modules()) is True
+
+
+# ---------- bootstrap_modules: install path ----------
+
+
+def test_bootstrap_skips_already_installed(tmp_path, monkeypatch, capsys):
+    vvmq = str(tmp_path)
+    _write(os.path.join(vvmq, "luarocks.exe"))
+    _write_mq2lua(vvmq)
+    tree = _make_tree(vvmq, TEST_JIT_VERSION)
+    _write(luarocks._file_in_tree(tree, "lfs.dll"))
+    _write(luarocks._file_in_tree(tree, "lsqlite3.dll"))
+
+    _enable_win(monkeypatch, vvmq)
+    _patch_manifest(monkeypatch, [
+        Rock(name="luafilesystem", files=["lfs.dll"]),
+        Rock(name="lsqlite3", files=["lsqlite3.dll"]),
+    ])
+    monkeypatch.setattr(luarocks.subprocess, "run", _no_call)
+
+    assert _run(luarocks.bootstrap_modules()) is True
+    assert "up-to-date" in capsys.readouterr().out
+
+
+def test_bootstrap_installs_missing_and_verifies(tmp_path, monkeypatch, capsys):
+    vvmq = str(tmp_path)
+    _write(os.path.join(vvmq, "luarocks.exe"))
+    _write_mq2lua(vvmq)
+    tree = os.path.join(vvmq, "modules", TEST_JIT_VERSION, "luarocks")
+
+    rocks = [
+        Rock(name="luafilesystem", files=["lfs.dll"]),
+        Rock(name="lsqlite3", files=["lsqlite3.dll"]),
+    ]
+    _enable_win(monkeypatch, vvmq)
+    _patch_manifest(monkeypatch, rocks)
+
+    name_to_files = {r.name: r.files for r in rocks}
+
+    def _fake_run(cmd, *_a, **_kw):
+        name = cmd[-1]
+        # Simulate luarocks dropping the DLLs so verification passes.
+        for f in name_to_files[name]:
+            _write(luarocks._file_in_tree(tree, f))
+        return _FakeCompleted(stdout=f"{name} 1.0-1 is now installed")
+
+    monkeypatch.setattr(luarocks.subprocess, "run", _fake_run)
+
+    events: list[tuple] = []
+    assert _run(luarocks.bootstrap_modules(on_event=events.append)) is True
+
+    kinds = [e[0] for e in events]
+    assert kinds.count("add_total") == 1
+    assert kinds.count("start") == 2
+    done = [e for e in events if e[0] == "done"]
+    assert len(done) == 2
+    assert all(e[2] == "downloaded" for e in done)
+    out = capsys.readouterr().out
+    assert "installing 2 module(s)" in out  # heads-up before the slow part
+    assert "can take several minutes" in out
+    assert "installed 2 module(s)" in out
+
+
+def test_bootstrap_marks_already_installed_as_skipped(tmp_path, monkeypatch, capsys):
+    vvmq = str(tmp_path)
+    _write(os.path.join(vvmq, "luarocks.exe"))
+    _write_mq2lua(vvmq)
+
+    _enable_win(monkeypatch, vvmq)
+    _patch_manifest(monkeypatch, [Rock(name="fun")])
+
+    def _fake_run(cmd, *_a, **_kw):
+        return _FakeCompleted(stdout="fun 0.1-1 is already installed in tree.", returncode=0)
+
+    monkeypatch.setattr(luarocks.subprocess, "run", _fake_run)
+
+    events: list[tuple] = []
+    assert _run(luarocks.bootstrap_modules(on_event=events.append)) is True
+
+    assert [e for e in events if e[0] == "done"] == [("done", "fun", "skipped")]
+    out = capsys.readouterr().out
+    # Skipped (already-present) rocks stay quiet; the run just reports up-to-date.
+    assert "fun already installed" not in out
+    assert "up-to-date" in out
+
+
+def test_bootstrap_skips_recorded_pure_lua_without_running(tmp_path, monkeypatch, capsys):
+    # A pure-Lua rock already in the tree's rocks db must not re-run the slow install.
+    vvmq = str(tmp_path)
+    _write(os.path.join(vvmq, "luarocks.exe"))
+    _write_mq2lua(vvmq)
+    tree = _make_tree(vvmq, TEST_JIT_VERSION)
+    os.makedirs(os.path.join(tree, "lib", "luarocks", "rocks-5.1", "fun"))
+
+    _enable_win(monkeypatch, vvmq)
+    _patch_manifest(monkeypatch, [Rock(name="fun")])
+    monkeypatch.setattr(luarocks.subprocess, "run", _no_call)
+
+    assert _run(luarocks.bootstrap_modules()) is True
+    assert "up-to-date" in capsys.readouterr().out
+
+
+def test_bootstrap_flags_missing_dll_after_install(tmp_path, monkeypatch, capsys):
+    """luarocks reports success but the DLL never lands (antivirus case)."""
+    vvmq = str(tmp_path)
+    _write(os.path.join(vvmq, "luarocks.exe"))
+    _write_mq2lua(vvmq)
+
+    _enable_win(monkeypatch, vvmq)
+    _patch_manifest(monkeypatch, [Rock(name="luafilesystem", files=["lfs.dll"])])
+    # Reports success but writes nothing.
+    monkeypatch.setattr(
+        luarocks.subprocess, "run",
+        lambda *a, **kw: _FakeCompleted(stdout="luafilesystem 1.0-1 is now installed"),
+    )
+
+    events: list[tuple] = []
+    assert _run(luarocks.bootstrap_modules(on_event=events.append)) is False
+
+    done = [e for e in events if e[0] == "done"]
+    assert done == [("done", "luafilesystem", "error")]
+    out = capsys.readouterr().out
+    assert "missing" in out
+    assert "Hints:" in out
+
+
+def test_bootstrap_reports_failure_and_returns_false(tmp_path, monkeypatch, capsys):
+    vvmq = str(tmp_path)
+    _write(os.path.join(vvmq, "luarocks.exe"))
+    _write_mq2lua(vvmq)
+
+    _enable_win(monkeypatch, vvmq)
+    _patch_manifest(monkeypatch, [Rock(name="lyaml", files=["yaml.dll"])])
+
+    def _fake_run(cmd, *_a, **_kw):
+        return _FakeCompleted(stderr="Error: download failed", returncode=1)
+
+    monkeypatch.setattr(luarocks.subprocess, "run", _fake_run)
+
+    events: list[tuple] = []
+    assert _run(luarocks.bootstrap_modules(on_event=events.append)) is False
+
+    done = [e for e in events if e[0] == "done"]
+    assert done == [("done", "lyaml", "error")]
+    out = capsys.readouterr().out
+    assert "failed to install" in out
+    assert "Hints:" in out
+
+
+def test_bootstrap_emits_luarocks_failed_event_with_redist_url(tmp_path, monkeypatch):
+    """On failure the UI gets a luarocks_failed event carrying the matching redist URL."""
+    vvmq = str(tmp_path)
+    _write(os.path.join(vvmq, "luarocks.exe"))
+    _write_mq2lua(vvmq, machine=luarocks.IMAGE_FILE_MACHINE_I386)  # 32-bit build
+
+    _enable_win(monkeypatch, vvmq)
+    _patch_manifest(monkeypatch, [Rock(name="lyaml", files=["yaml.dll"])])
+    monkeypatch.setattr(
+        luarocks.subprocess, "run",
+        lambda *a, **kw: _FakeCompleted(stderr="Error: download failed", returncode=1),
+    )
+
+    events: list[tuple] = []
+    assert _run(luarocks.bootstrap_modules(on_event=events.append)) is False
+
+    # Bitness comes from the DLL's PE header, not the env.
+    assert ("luarocks_failed", luarocks.VC_REDIST_X86, None) in events
+
+
+def test_bootstrap_no_failure_event_on_success(tmp_path, monkeypatch):
+    """A clean run must not emit a luarocks_failed event."""
+    vvmq = str(tmp_path)
+    _write(os.path.join(vvmq, "luarocks.exe"))
+    _write_mq2lua(vvmq)
+    tree = _make_tree(vvmq, TEST_JIT_VERSION)
+
+    _enable_win(monkeypatch, vvmq)
+    _patch_manifest(monkeypatch, [Rock(name="luafilesystem", files=["lfs.dll"])])
+
+    def _fake_run(cmd, *_a, **_kw):
+        _write(luarocks._file_in_tree(tree, "lfs.dll"))
+        return _FakeCompleted(stdout="luafilesystem 1.0-1 is now installed")
+
+    monkeypatch.setattr(luarocks.subprocess, "run", _fake_run)
+
+    events: list[tuple] = []
+    assert _run(luarocks.bootstrap_modules(on_event=events.append)) is True
+    assert not any(e[0] == "luarocks_failed" for e in events)
+
+
+# ---------- is_luarocks_enabled ----------
+
+
+def test_is_luarocks_enabled_default_on(monkeypatch):
+    settings = SimpleNamespace(ENV="LIVE", from_env=lambda env: {})
+    monkeypatch.setattr(luarocks.config, "settings", settings)
+    assert luarocks.is_luarocks_enabled() is True
+
+
+def test_is_luarocks_enabled_explicit_false(monkeypatch):
+    settings = SimpleNamespace(ENV="LIVE", from_env=lambda env: {"LUAROCKS_ENABLED": False})
+    monkeypatch.setattr(luarocks.config, "settings", settings)
+    assert luarocks.is_luarocks_enabled() is False


### PR DESCRIPTION
Hopefully this will address most of #19 , or at least get people angry at redfetch rather than rgmercs. 

This solution runs luarocks.exe from redfetch as part of a normal "easy update", using version information pulled from MQ2Lua.dll 
It will grab **all** rocks curated by MacroQuest devs, which takes several minutes. 

On failure it will post some common solutions. 

Since antivir has been known to remove rocks dll files, we search for their existence regardless of what luarocks reports. 