### PR TITLE
Fix Very Vanilla MQ path validation

### DIFF
--- a/src/redfetch/config.py
+++ b/src/redfetch/config.py
@@ -121,7 +121,7 @@ def normalize_paths_in_dict(data, parent_key=None):
             elif key in ['default_path', 'custom_path'] and isinstance(value, str):
                 normalized_value = os.path.normpath(value) if value else value
                 parent_key_int = int(parent_key) if isinstance(parent_key, str) and parent_key.isdigit() else parent_key
-                if parent_key_int not in EQMAPS_MAP:
+                if parent_key_int not in EQMAPS_MAP and os.path.isabs(normalized_value):
                     validate_no_eqgame(normalized_value)
                 data[key] = normalized_value
     elif isinstance(data, list):

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,33 @@
+from dynaconf import ValidationError
+import pytest
+
+from redfetch.config import normalize_paths_in_dict
+
+
+def test_special_resource_relative_path_skips_eqgame_validation():
+    data = {
+        "1974": {
+            "default_path": "VanillaMQ_LIVE",
+        }
+    }
+
+    normalized = normalize_paths_in_dict(data)
+
+    assert normalized["1974"]["default_path"] == "VanillaMQ_LIVE"
+
+
+def test_special_resource_absolute_path_still_rejects_eqgame_parent(tmp_path):
+    eq_root = tmp_path / "EverQuest"
+    vv_path = eq_root / "VanillaMQ_LIVE"
+    eq_root.mkdir()
+    vv_path.mkdir()
+    (eq_root / "eqgame.exe").write_text("", encoding="utf-8")
+
+    data = {
+        "1974": {
+            "default_path": str(vv_path),
+        }
+    }
+
+    with pytest.raises(ValidationError, match=r"contains eqgame\.exe"):
+        normalize_paths_in_dict(data)


### PR DESCRIPTION
## Summary

Fixes Very Vanilla MQ path validation so relative packaged defaults are allowed, while absolute paths that point under an EverQuest folder containing `eqgame.exe` still hard-error clearly.

## Why

RedFetch needs the MacroQuest folder, not an EverQuest executable path. This preserves bundled relative special-resource defaults while still catching user-selected invalid absolute MQ paths early.

## Details

- Only runs `eqgame.exe` parent validation for absolute special-resource paths.
- Adds tests for relative defaults and absolute invalid Very Vanilla MQ paths.

## Validation

- `uv run --with pytest pytest tests/test_config_validation.py`
- `uv run --with pytest --with pytest-mock pytest`
- `python -m compileall -q src tests`
- `git diff --check origin/main...HEAD`

Related to RedGuides/redfetch#22