### PR TITLE
Fix spelling of wallpaper in config_firstrun.py

### DIFF
--- a/src/redfetch/config_firstrun.py
+++ b/src/redfetch/config_firstrun.py
@@ -463,7 +463,7 @@ def first_run_setup():
         default_choice = bool(os.environ.get("PYAPP"))
 
         console.print(
-            "\n[bold cyan][italic]\"Shall we set a signe upon thy fair anime walpaper?\"[/italic][/bold cyan]"
+            "\n[bold cyan][italic]\"Shall we set a signe upon thy fair anime wallpaper?\"[/italic][/bold cyan]"
         )
         wants_shortcut = CustomConfirm.ask(
             "Create Desktop shortcut?",


### PR DESCRIPTION
Fix spelling of "wallpaper" in the first-run desktop shortcut prompt in config_firstrun.py